### PR TITLE
migrate: use new lutaml SPA with Vue 3 frontend

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - migrate/new-lutaml-spa
   workflow_dispatch:
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 
 # Generated files
 browser.html
+index.html

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "lutaml", github: "lutaml/lutaml", branch: "rt-new-features"
+gem "lutaml", github: "lutaml/lutaml", branch: "refactor/typed-spa-data-layer-vue-migration"


### PR DESCRIPTION
## Summary

Migrate from the old `rt-new-features` branch to the new lutaml SPA frontend built on the `refactor/typed-spa-data-layer-vue-migration` branch.

## Changes

- **Gemfile**: Update lutaml gem source from `rt-new-features` to `refactor/typed-spa-data-layer-vue-migration`
- **CI**: Add `migrate/new-lutaml-spa` branch to trigger deployments
- **.gitignore**: Add `index.html` (generated file)

## What the new SPA includes

- Modern Vue 3 + Pinia frontend with full-width responsive layout
- Dark/light theme toggle with proper `[data-theme]` CSS variables
- SVG icons throughout (no more HTML entity rendering issues)
- Proper sidebar with collapse, package tree navigation, stats grid, and footer branding
- Aligned CSS class names between Vue components and the design system
- Fixed generalization resolver to handle String values in PLATEAU model data
- Puppeteer e2e tests verifying rendering (10 tests, all passing)

## Verification

Generated HTML (3.55MB) renders correctly:
- Full width layout (1400px viewport)
- Header at 56px, sidebar at 320px, content at 1080px  
- No JS console errors
- Dark mode toggle works
- Sidebar collapse/expand works
- Search modal opens with `/` key
- Package tree navigation works

## Screenshot

See deployment from this branch for live preview.